### PR TITLE
Changed default directory for generating steps file to the same directory as the .feature file

### DIFF
--- a/TechTalk.SpecFlow.VsIntegration.Implementation/UI/GenerateStepDefinitionSkeletonForm.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/UI/GenerateStepDefinitionSkeletonForm.cs
@@ -85,7 +85,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.UI
             classNameTextBox.Text = string.Format("{0} Steps", featureTitle).ToIdentifier();
 
             styleComboBox.BeginUpdate();
-            var styles = Enum.GetValues(typeof (StepDefinitionSkeletonStyle)).Cast<StepDefinitionSkeletonStyle>()
+            var styles = Enum.GetValues(typeof(StepDefinitionSkeletonStyle)).Cast<StepDefinitionSkeletonStyle>()
                 .Where(value => value != StepDefinitionSkeletonStyle.MethodNameRegex || defaultLanguage == ProgrammingLanguage.FSharp)
                 .ToArray();
             styleComboBox.Items.Clear();
@@ -97,7 +97,10 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.UI
 
             defaultFolder = Path.Combine(VsxHelper.GetProjectFolder(specFlowProject), "StepDefinitions");
             if (!Directory.Exists(defaultFolder))
-                defaultFolder = VsxHelper.GetProjectFolder(specFlowProject);
+            {
+                var currentFeatureFilePath = dte.ActiveDocument.FullName;
+                defaultFolder = Path.GetDirectoryName(currentFeatureFilePath);
+            }
         }
 
         private void selectAllButton_Click(object sender, EventArgs e)
@@ -134,6 +137,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.UI
         private void generateButton_Click(object sender, EventArgs e)
         {
             saveFileDialog.FileName = Path.Combine(defaultFolder, ClassName);
+            saveFileDialog.InitialDirectory = defaultFolder;
             if (saveFileDialog.ShowDialog() == DialogResult.OK)
             {
                 if (OnGenerate(this, saveFileDialog.FileName))


### PR DESCRIPTION
First it will try to find the folder <projectfolder>/StepDefinitions (current code)
If not found, then use the directory where the .feature file lives

fixes https://github.com/SpecFlowOSS/SpecFlow/issues/1638

Tested it locally with VS2019 multiple times. 

Todo

- [ ] update changelog