### PR TITLE
Fix: Renaming a step should not change the parameters

### DIFF
--- a/SpecFlowStarterProjectTemplate/ProjectTemplate.csproj
+++ b/SpecFlowStarterProjectTemplate/ProjectTemplate.csproj
@@ -6,26 +6,26 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="SpecFlow.Plus.LivingDocPlugin" Version="3.4.243" />
+    <PackageReference Include="SpecFlow.Plus.LivingDocPlugin" Version="3.5.186" />
 
     $if$ ('$unittestframework$' == 'runner')
     <PackageReference Include="SpecRun.SpecFlow" Version="3.5.8" />
     $endif$
 
     $if$ ('$unittestframework$' == 'xunit')
-    <PackageReference Include="SpecFlow.xUnit" Version="3.5.5" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.5.14" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     $endif$
 
     $if$ ('$unittestframework$' == 'nunit')
-    <PackageReference Include="SpecFlow.NUnit" Version="3.5.5" />
+    <PackageReference Include="SpecFlow.NUnit" Version="3.5.14" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     $endif$
 
     $if$ ('$unittestframework$' == 'mstest')
-    <PackageReference Include="SpecFlow.MsTest" Version="3.5.5" />
+    <PackageReference Include="SpecFlow.MsTest" Version="3.5.14" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     $endif$

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/DefaultDependencyProvider.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/DefaultDependencyProvider.cs
@@ -9,6 +9,7 @@ using TechTalk.SpecFlow.IdeIntegration.Options;
 using TechTalk.SpecFlow.IdeIntegration.Tracing;
 using TechTalk.SpecFlow.VsIntegration.Implementation.Analytics;
 using TechTalk.SpecFlow.VsIntegration.Implementation.Commands;
+using TechTalk.SpecFlow.VsIntegration.Implementation.EditorCommands;
 using TechTalk.SpecFlow.VsIntegration.Implementation.Install;
 using TechTalk.SpecFlow.VsIntegration.Implementation.LanguageService;
 using TechTalk.SpecFlow.VsIntegration.Implementation.Services;
@@ -48,6 +49,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation
             container.RegisterTypeAs<StepDefinitionSkeletonProvider, IStepDefinitionSkeletonProvider>();
             container.RegisterTypeAs<DefaultSkeletonTemplateProvider, ISkeletonTemplateProvider>();
             container.RegisterTypeAs<StepTextAnalyzer, IStepTextAnalyzer>();
+            container.RegisterTypeAs<StepNameReplacer, IStepNameReplacer>();
 
             container.RegisterTypeAs<TelemetryClientWrapper, TelemetryClientWrapper>();
             container.RegisterTypeAs<AppInsightsEventConverter, IAppInsightsEventConverter>();

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/EditorCommands/IStepNameReplacer.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/EditorCommands/IStepNameReplacer.cs
@@ -1,0 +1,9 @@
+﻿using TechTalk.SpecFlow.Bindings;
+
+namespace TechTalk.SpecFlow.VsIntegration.Implementation.EditorCommands
+{
+    public interface IStepNameReplacer
+    {
+        public string BuildStepNameWithNewRegex(string stepName, string newStepRegex, IStepDefinitionBinding binding);
+    }
+}

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/EditorCommands/StepNameReplacer.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/EditorCommands/StepNameReplacer.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Text;
+using System.Text.RegularExpressions;
+using TechTalk.SpecFlow.Bindings;
+
+namespace TechTalk.SpecFlow.VsIntegration.Implementation.EditorCommands
+{
+    public class StepNameReplacer : IStepNameReplacer
+    {
+        public string BuildStepNameWithNewRegex(string stepName, string newStepRegex, IStepDefinitionBinding binding)
+        {
+            var originalMatch = Regex.Match(stepName, FormatRegexForDisplay(binding.Regex));
+
+            var newRegexMatch = Regex.Match(newStepRegex, newStepRegex);
+            // Regex pattern "the number is (\d+)" will not match the input "the number is (\d+)"
+            // replace (\d+) to (.*) in the pattern so it will match
+            if (!newRegexMatch.Success)
+            {
+                var newStepRegexForMatching = Regex.Replace(newStepRegex, @"\(.*?\)", "(.*)");
+                newRegexMatch = Regex.Match(newStepRegex, newStepRegexForMatching);
+            }
+
+            // we cannot support the parameter number change,
+            // because we will not know where to put the values
+            if (originalMatch.Groups.Count != newRegexMatch.Groups.Count)
+            {
+                throw new NotSupportedException("Changing the number of parameters is not supported!");
+            }
+
+            var builder = new StringBuilder(newStepRegex);
+            for (var i = newRegexMatch.Groups.Count - 1; i > 0; i--)
+            {
+                builder.Replace(newRegexMatch.Groups[i].Value, originalMatch.Groups[i].Value, newRegexMatch.Groups[i].Index, newRegexMatch.Groups[i].Length);
+            }
+
+            return RemoveDoubleQuotes(builder.ToString());
+        }
+
+        private static string FormatRegexForDisplay(Regex regex)
+        {
+            return RemoveDoubleQuotes(TrimLast(TrimFirst(regex.ToString())));
+        }
+
+        private static string RemoveDoubleQuotes(string value)
+        {
+            return value.Replace("\"\"", "\""); ;
+        }
+
+        private static string TrimFirst(string value)
+        {
+            return value.Remove(0, 1);
+        }
+
+        private static string TrimLast(string value)
+        {
+            return value.Remove(value.Length - 1, 1);
+        }
+    }
+}

--- a/UnitTests/VsIntegration.Implementation.UnitTests/StepNameReplacerTests.cs
+++ b/UnitTests/VsIntegration.Implementation.UnitTests/StepNameReplacerTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Bindings;
+using TechTalk.SpecFlow.Bindings.Reflection;
+using TechTalk.SpecFlow.VsIntegration.Implementation.EditorCommands;
+
+namespace TechTalk.SpecFlow.VsIntegration.Implementation.UnitTests
+{
+    public class StepNameReplacerTests
+    {
+        [TestCase("the hungarian calculator", @"the hungarian calculator", "the russian calculator", "the russian calculator")]
+        [TestCase("the first number is 50", @"the first number is (.*)", "the number is (.*)", "the number is 50")]
+        [TestCase("the first number is 50", @"the first number is (\d+)", @"the number is (\d+)", "the number is 50")]
+        [TestCase("The car should be painted blue", @"The car should be painted (blue|yellow|green)", @"The car is (blue|yellow|green)", "The car is blue")]
+        public void Should_CalculateCorrectStepName_WhenParametersAreTheSame(string stepName, string originalStepRegex, string newRegex, string expectedStepName)
+        {
+            var binding = CreateStepDefinitionBinding(originalStepRegex);
+
+            var sut = new StepNameReplacer();
+            var result = sut.BuildStepNameWithNewRegex(stepName, newRegex, binding);
+
+            result.Should().Be(expectedStepName);
+        }
+
+        [TestCase("my 10 and your 20", @"my (.*) and your (.*)", @"your and mine: (.*), (.*)", "your and mine: 10, 20")]
+        [TestCase("my 10 and your 20", @"my (\d+) and your (\d+)", @"your and mine: (\d+), (\d+)", "your and mine: 10, 20")]
+        public void Should_CalculateCorrectStepName_WhenReorderingTheParameters(string stepName, string originalStepRegex, string newRegex, string expectedStepName)
+        {
+            var binding = CreateStepDefinitionBinding(originalStepRegex);
+
+            var sut = new StepNameReplacer();
+            var result = sut.BuildStepNameWithNewRegex(stepName, newRegex, binding);
+
+            result.Should().Be(expectedStepName);
+        }
+
+        [Test]
+        public void Should_ThrowAnException_WhenChangingTheNumberOfParameters()
+        {
+            var stepName = "the number is 50";
+            var originalRegex = "the number is (.*)";
+            var newRegex = "the numbers are (.*) and (.*)";
+            var binding = CreateStepDefinitionBinding(originalRegex);
+
+            var sut = new StepNameReplacer();
+
+            Assert.Throws<NotSupportedException>(() =>
+                    sut.BuildStepNameWithNewRegex(stepName, newRegex, binding));
+        }
+
+        private StepDefinitionBinding CreateStepDefinitionBinding(string regex)
+        {
+            var bindingType = new BindingType("StepNameReplacerTests", "UnitTests.StepNameReplacerTests");
+            var bindingScope = new BindingScope(null, null, null);
+            var bindingMethod = new BindingMethod(bindingType, "", Enumerable.Empty<IBindingParameter>(), bindingType);
+
+            var binding = new StepDefinitionBinding(StepDefinitionType.Given, regex, bindingMethod, bindingScope);
+
+            return binding;
+        }
+    }
+}


### PR DESCRIPTION
Renaming a step (with parameters) in a feature file caused the parameters in the step names to be replaced to the regex, so the former values got overwritten.

![vs-rename](https://user-images.githubusercontent.com/24826269/101468573-e4d9c080-3943-11eb-94a5-83d04c86be22.gif)

Only steps with different regex than `(.*)` were affected.

Examples of bad behaviour:
- RegEx with numbers (shown in the previous gif):
Step name: `the first number is 50`
Binding regex: `the first number is (\d+)`
If you rename this Step to `the number is (\d+)`, then all occurrences in the feature files were changed to `the number is (\d+)
`
- RegEx values as a string:
Step name: `The car should be painted yellow`
Binding regex: `The car should be painted (blue|yellow|green)`
If you rename this Step to `The car is (blue|yellow|green)`, then all occurrences in the feature files were changed to 
`The car is (blue|yellow|green)`

Fixes https://github.com/SpecFlowOSS/SpecFlow/issues/1528
Continued the work started in #75 

Limitations:
- Changing the number of parameters is not supported (because we will not know where to put the values)
So changing `the number is (\d+)` to `the numbers are (\d+), (\d+)` is not supported.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [x] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
