### PR TITLE
Initial version for supporting step argument suggestions for enum types

### DIFF
--- a/TechTalk.SpecFlow.VsIntegration.Implementation/AutoComplete/GherkinCompletionCommandFilter.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/AutoComplete/GherkinCompletionCommandFilter.cs
@@ -27,9 +27,10 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.AutoComplete
             {
                 return GherkinStepCompletionSource.IsKeywordPrefix(caret, languageService);
             }
-            if (GherkinStepCompletionSource.IsStepLine(caret, languageService))
+            if (ch == ' ' && GherkinStepCompletionSource.IsStepLine(caret, languageService))
             {
-                return ch == ' ' && GherkinStepCompletionSource.IsKeywordPrefix(caret - 1, languageService); 
+                return GherkinStepCompletionSource.IsKeywordPrefix(caret - 1, languageService) // step completion
+                    || GherkinStepCompletionSource.IsStepArgument(caret, languageService); // step argument completion
             }
 
             return false;

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/Bindings/Discovery/VsBindingRegistryBuilder.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/Bindings/Discovery/VsBindingRegistryBuilder.cs
@@ -4,11 +4,13 @@ using System.Linq;
 using EnvDTE;
 using EnvDTE80;
 using TechTalk.SpecFlow.Bindings;
+using TechTalk.SpecFlow.Bindings.Reflection;
 using TechTalk.SpecFlow.Bindings.Discovery;
 using TechTalk.SpecFlow.IdeIntegration.Bindings;
 using TechTalk.SpecFlow.IdeIntegration.Tracing;
 using TechTalk.SpecFlow.VsIntegration.Implementation.LanguageService;
 using TechTalk.SpecFlow.VsIntegration.Implementation.Utils;
+using TechTalk.SpecFlow.VsIntegration.Implementation.StepSuggestions;
 
 namespace TechTalk.SpecFlow.VsIntegration.Implementation.Bindings.Discovery
 {
@@ -34,6 +36,26 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.Bindings.Discovery
             relatedProjectItems = new List<ProjectItem>();
             ProcessBindingsFromProjectItem(projectItem, bindingProcessor, relatedProjectItems);
             return bindingProcessor.ReadStepDefinitionBindings();
+        }
+
+        public IEnumerable<StepArgumentType> GetStepArgumentTypesFromProjectItem(ProjectItem projectItem)
+        {
+            List<StepArgumentType> stepArgumentTypes = new List<StepArgumentType>();
+            foreach (CodeEnum codeEnum in VsxHelper.GetEnums(projectItem))
+            {
+                List<string> values = new List<string>();
+                foreach (CodeElement member in codeEnum.Members)
+                {
+                    values.Add(member.Name);
+                }
+
+                StepArgumentType stepArgumentType = new StepArgumentType();
+                stepArgumentType.Type = new BindingType(codeEnum.Name, codeEnum.FullName);
+                stepArgumentType.Values = values;
+
+                stepArgumentTypes.Add(stepArgumentType);
+            }
+            return stepArgumentTypes;
         }
 
         private void ProcessBindingsFromProjectItem(ProjectItem projectItem, IdeBindingSourceProcessor bindingSourceProcessor, List<ProjectItem> relatedProjectItems)

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/LanguageService/BindingFileInfo.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/LanguageService/BindingFileInfo.cs
@@ -4,6 +4,7 @@ using System.IO;
 using EnvDTE;
 using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.VsIntegration.Implementation.Utils;
+using TechTalk.SpecFlow.VsIntegration.Implementation.StepSuggestions;
 using VSLangProj;
 
 namespace TechTalk.SpecFlow.VsIntegration.Implementation.LanguageService
@@ -11,6 +12,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.LanguageService
     public class BindingFileInfo : FileInfo
     {
         public IEnumerable<IStepDefinitionBinding> StepBindings { get; set; }
+        public IEnumerable<StepArgumentType> StepArgumentTypes { get; set; }
 
         public bool IsAssembly
         {

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/LanguageService/BindingFilesTracker.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/LanguageService/BindingFilesTracker.cs
@@ -120,6 +120,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.LanguageService
                 List<ProjectItem> relatedProjectItems;
                 fileInfo.StepBindings = stepSuggestionBindingCollector.GetBindingsFromProjectItem(projectItem, out relatedProjectItems).ToArray();
                 relatedFiles = relatedProjectItems.Select(pi => FindFileInfo(VsxHelper.GetProjectRelativePath(pi))).Where(fi => fi != null).Distinct().ToList();
+                fileInfo.StepArgumentTypes = stepSuggestionBindingCollector.GetStepArgumentTypesFromProjectItem(projectItem);
                 fileInfo.LastChangeDate = VsxHelper.GetLastChangeDate(projectItem) ?? DateTime.MinValue;
             }
         }
@@ -184,6 +185,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.LanguageService
 
                 fileStepDefinitions.StepDefinitions = new List<StepDefinitionBindingItem>();
                 fileStepDefinitions.StepDefinitions.AddRange(bindingFileInfo.StepBindings.Select(StepDefinitionBindingItem.FromStepDefinitionBinding));
+                fileStepDefinitions.StepArgumentTypes = bindingFileInfo.StepArgumentTypes.ToList();
                 projectStepDefinitions.FileStepDefinitions.Add(fileStepDefinitions);
             }
         }
@@ -222,6 +224,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.LanguageService
                         continue;
 
                     fileInfo.StepBindings = fileStepDefinitions.StepDefinitions.Select(bi => bi.ToStepDefinitionBinding()).ToList();
+                    fileInfo.StepArgumentTypes = fileStepDefinitions.StepArgumentTypes;
 
                     FireFileUpdated(fileInfo);
                     fileInfo.IsError = false;

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/StepSuggestions/FileStepDefinitions.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/StepSuggestions/FileStepDefinitions.cs
@@ -8,5 +8,6 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.StepSuggestions
         public string FileName { get; set; }
         public DateTime TimeStamp { get; set; }
         public List<StepDefinitionBindingItem> StepDefinitions { get; set; }
+        public List<StepArgumentType> StepArgumentTypes { get; set; }
     }
 }

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/StepSuggestions/StepArgumentType.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/StepSuggestions/StepArgumentType.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using TechTalk.SpecFlow.Bindings.Reflection;
+
+namespace TechTalk.SpecFlow.VsIntegration.Implementation.StepSuggestions
+{
+    public class StepArgumentType
+    {
+        public IBindingType Type { get; set; }
+        public IEnumerable<string> Values { get; set; }
+    }
+}

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/StepSuggestions/StepMap.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/StepSuggestions/StepMap.cs
@@ -11,7 +11,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.StepSuggestions
 {
     public class StepMap
     {
-        public const int CURRENT_VERSION = 3;
+        public const int CURRENT_VERSION = 4;
 
         public static StepMap CreateStepMap(CultureInfo defaultLanguage)
         {

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/Utils/VsxHelper.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/Utils/VsxHelper.cs
@@ -426,6 +426,32 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.Utils
             }
         }
 
+        public static IEnumerable<CodeEnum> GetEnums(ProjectItem projectItem)
+        {
+            if (projectItem.FileCodeModel == null || projectItem.FileCodeModel.CodeElements == null)
+                return Enumerable.Empty<CodeEnum>();
+
+            return GetEnums(projectItem.FileCodeModel.CodeElements);
+        }
+
+        private static IEnumerable<CodeEnum> GetEnums(CodeElements codeElements)
+        {
+            foreach (CodeElement codeElement in codeElements)
+            {
+                if (codeElement.Kind == vsCMElement.vsCMElementNamespace ||
+                    codeElement.Kind == vsCMElement.vsCMElementClass)
+                {
+                    foreach (var codeEnum in GetEnums(codeElement.Children))
+                        yield return codeEnum;
+                }
+                else if (codeElement.Kind == vsCMElement.vsCMElementEnum)
+                {
+                    CodeEnum codeEnum = (CodeEnum)codeElement;
+                    yield return codeEnum;
+                }
+            }
+        }
+
         public static IEnumerable<CodeClass> GetClasses(ProjectItem projectItem)
         {
             if (projectItem.FileCodeModel == null || projectItem.FileCodeModel.CodeElements == null)


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines 
(https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->

I implemented an initial version for step argument suggestions when editing feature files in Visual Studio. It is at least a first step to solve [Issue #1850](https://github.com/SpecFlowOSS/SpecFlow/issues/1850). See also my comment there for more information about this change.

Since this is my first contribution to SpecFlow, I'd like to share some thoughts and questions I had during implementation:

1. Would it make sense / is it possible to implement step argument suggestions in dedicated classes? From my perspective there is a large overlap with the existing step suggestions, so I did most of the implementation directly in the existing classes. I'm also not sure if Visual Studio would support e.g. the registration of a second completion source for Gherkin files.
2. The new method VsBindingRegistryBuilder.GetStepArgumentTypesFromProjectItem introduces some computational overhead, because it processes the project item another time. This could be done more efficiently in the existing GetBindingsFromProjectItem method. This would need some deeper refactoring of existing code, which I tried to avoid in this first step.
3. Classes BindingFileInfo, VsStepSuggestionProvider, FileStepDefinitions and StepSuggestionProvider were extended with lists / dictionaries of step argument types. Here I'm unsure if this should be implemented at least partially in dedicated classes, or if some of the classes should be renamed. E.g. it makes sense to hold information about step definitions and step argument types defined in a single file in one class (FileStepDefinitions), but it could make sense to change the class name (e.g. to FileDefinitions).
4. As a consequence, class StepMap now also includes information about step argument types, including the serialization into the cache file. I think it makes sense to have all information in a single cache file (otherwise there would be a lot of overhead for writing/reading two cache files, and potentially some inconsistency between the files). However, as mentioned before, a different naming might improve code readability. On the other hand, step definitions and step arguments are still quite closely related, so the existing naming might also be ok.
5. I'm a bit concerned about the VSTHRD010 warnings reporting access to VS objects from the wrong thread. Although there were already a lot of such warnings before (and to my understanding the objects are indeed often accessed from a wrong thread), my additional code might raise the probability of stability problems. At least from time to time I get NullReference exceptions at DTE object access during VS shutdown, when I have the debugger attached and save a code file shortly before closing VS.
6. Are there any automated tests that need to be adapted? At least I did not find anything about automated integration tests for Visual Studio.
7. Which configurations should be tested? So far I only tested with VS2019 and English language setting.


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
