### PR TITLE
Fix specflow.json template to generate a valid configuration

### DIFF
--- a/IdeIntegration/Configuration/JsonConfig/JsonConfigurationLoader.cs
+++ b/IdeIntegration/Configuration/JsonConfig/JsonConfigurationLoader.cs
@@ -35,7 +35,7 @@ namespace TechTalk.SpecFlow.IdeIntegration.Configuration.JsonConfig
             {
                 if (!string.IsNullOrWhiteSpace(jsonConfig.BindingCulture.Name))
                 {
-                    featureLanguage = CultureInfo.GetCultureInfo(jsonConfig.BindingCulture.Name);
+                    bindingCulture = CultureInfo.GetCultureInfo(jsonConfig.BindingCulture.Name);
                 }
             }
 

--- a/ItemTemplates/SpecFlowJson/specflow.json
+++ b/ItemTemplates/SpecFlowJson/specflow.json
@@ -1,7 +1,7 @@
 ﻿{
     "bindingCulture":
     {
-        "language" :"en-us"
+        "name" :"en-us"
     },
     "language":
     {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 Upcoming
++ Fix specflow.json template to generate a valid configuration
+
+2019.0.83 - 2021-04-01
 + Update guidance sequence
 
 2019.0.80 - 2021-02-17


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines 
(https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->

Currently if we add a `specflow.json` file through Item templates, it generates an invalid configuration:
```
{
    "bindingCulture":
    {
        "language" :"en-us"
    },
    "language":
    {
        "feature": "en-us"
    }
}
```
`bindingCulture` element have `name` attribute, not `language` (also written in [docs](https://docs.specflow.org/projects/specflow/en/latest/Installation/Configuration.html#bindingculture)).

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
