### PR TITLE
Fix WhiteSource Bolt reporting

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,5 @@ jobs:
       PathtoPublish: '$(Build.SourcesDirectory)/VsIntegration2017/bin/Release/TechTalk.SpecFlow.VsIntegration.2017.vsix'
       ArtifactName: VS2017
 
-  - task: whitesource.ws-bolt.bolt.wss.WhiteSource Bolt@19
+  - task: WhiteSource Bolt@20
     displayName: 'WhiteSource Bolt'
-    inputs:
-      advance: true


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines 
(https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->

WhiteSource Bolt is not reporting since December 2019. As I found out the problem was that we are using an older version of the WS Bolt build task. After updating it to the latest (version 20), it works again.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [x] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
