### PR TITLE
192-Inspect csproj to find the appconfig location

### DIFF
--- a/TechTalk.SpecFlow.VsIntegration.Implementation/Utils/VsxHelper.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/Utils/VsxHelper.cs
@@ -4,6 +4,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Xml.Linq;
+
 using EnvDTE;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
@@ -623,6 +625,22 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.Utils
             {
                 return null;
             }
+        }
+
+        public static string GetAppConfigPathFromCsProj(Project project)
+        {
+            XElement csProjXElement = XElement.Load(project.FileName);
+
+            string appConfigPath = csProjXElement
+                        .Element("PropertyGroup")?
+                        .Element("AppConfig")?
+                        .Value;
+            if (!string.IsNullOrEmpty(appConfigPath) && !Path.IsPathRooted(appConfigPath))
+            {
+                appConfigPath = Path.Combine(Path.GetDirectoryName(project.FileName), appConfigPath);
+            }
+
+            return appConfigPath;
         }
     }
 }

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/VsSpecFlowConfigurationReader.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/VsSpecFlowConfigurationReader.cs
@@ -1,4 +1,6 @@
-﻿using EnvDTE;
+﻿using System.IO;
+
+using EnvDTE;
 using TechTalk.SpecFlow.IdeIntegration.Generator;
 using TechTalk.SpecFlow.IdeIntegration.Tracing;
 using TechTalk.SpecFlow.VsIntegration.Implementation.Utils;
@@ -16,14 +18,20 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation
 
         protected override string GetConfigFileContent()
         {
-            var projectItem = VsxHelper.FindProjectItemByProjectRelativePath(_project, "specflow.json") ?? 
+            var projectItem = VsxHelper.FindProjectItemByProjectRelativePath(_project, "specflow.json") ??
                               VsxHelper.FindProjectItemByProjectRelativePath(_project, "app.config");
-            if (projectItem == null)
+            if (projectItem != null)
             {
-                return null;
+                return VsxHelper.GetFileContent(projectItem, true);
             }
 
-            return VsxHelper.GetFileContent(projectItem, true);
+            string configFilePath = VsxHelper.GetAppConfigPathFromCsProj(_project);
+            if (!string.IsNullOrEmpty(configFilePath) && File.Exists(configFilePath))
+            {
+                return File.ReadAllText(configFilePath);
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Fix bug issue #192
The App.config file may not be in the project items but it can be defined in the csproj file in the PropertyGroup->AppConfig element

<!-- If this is your first PR, please have a look at the Contribution Guidelines 
(https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
